### PR TITLE
[ci skip] adding user @CAM-Gerlach

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @djsutherland
+* @CAM-Gerlach

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,4 +52,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - CAM-Gerlach
     - djsutherland


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @CAM-Gerlach as instructed in #18.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #18